### PR TITLE
Handle reset

### DIFF
--- a/src/MLToolkit.Forms.SwipeCardView/SwipeCardView.cs
+++ b/src/MLToolkit.Forms.SwipeCardView/SwipeCardView.cs
@@ -389,6 +389,9 @@ namespace MLToolkit.Forms.SwipeCardView
                     card.IsVisible = false;
                 }
 
+                if (ItemsSource.Count > 0)
+                    Setup();
+
                 return;
             }
 


### PR DESCRIPTION
OnItemSourceCollectionChanged should really handle all operation types, but at least catching this allows for a full deck reset without empty spaces.

Please see https://github.com/markolazic88/SwipeCardView/issues/20